### PR TITLE
add Compliance Masonry to the list of projects we maintain

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ There are several components to the initial phase of 18F's compliance toolkit:
 ## Things we maintain
 
 * [The team Trello board](https://trello.com/b/QYPc32q1/compliance-toolkit)
+* [Compliance Masonry](https://github.com/opencontrol/compliance-masonry)
 * Compliance information in the [Before You Ship](https://pages.18f.gov/before-you-ship/) site (around ATOs, etc.)
 * [Compliance pipelines for Concourse](https://github.com/18F/concourse-compliance-testing)
 * [The Google Docs folder](https://drive.google.com/a/gsa.gov/folderview?id=0B5fn0WMJaYDnTVctaUgzZm94bnc&usp=sharing) (private)


### PR DESCRIPTION
This is more of a proposal than something that should be merged right away, but it came up in our roadmap planning last week that the Compliance Masonry project is probably closer aligned with the Compliance Toolkit than the platform work currently happening in the cloud.gov team.

@geramirez @DavidEBest @mogul Wouldn't want to merge without a :+1: from each of you. Thoughts?
