### PR TITLE
Re-naming #compliance-toolkit to #cloud-gov-highbar

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -104,8 +104,8 @@ licenses:
 #   text: Anchor text for the link
 #   category: Type of the link
 links:
-- url: https://trello.com/b/QYPc32q1/compliance-toolkit
-  text: Trello Board
+- url: https://github.com/18F/compliance-toolkit#boards
+  text: ZenHub Board
   category: process
 - url: https://compliance-viewer.18f.gov
   text: Compliance Viewer

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are several components to the initial phase of 18F's compliance toolkit:
 
 ### Compliance Concierge Service
 
-We’d like to offer ourselves up to support your ATO efforts. If you have a question about or need help with vulnerability scanning, static code analysis, or the ATO process in general, please reach out to us. Feel free to message us in #compliance-toolkit or tag us in an issue on Github with @18F/ato.
+We’d like to offer ourselves up to support your ATO efforts. If you have a question about or need help with vulnerability scanning, static code analysis, or the ATO process in general, please reach out to us. Feel free to message us in #cloud-gov-highbar or tag us in an issue on Github with @18F/ato.
 
 ### Short Term
 
@@ -43,7 +43,7 @@ We aim to:
 
 ## Things we maintain
 
-* [The team Trello board](https://trello.com/b/QYPc32q1/compliance-toolkit)
+* [The team ZenHub board](https://github.com/18F/compliance-toolkit#boards)
 * [Compliance Masonry](https://github.com/opencontrol/compliance-masonry)
 * Compliance information in the [Before You Ship](https://pages.18f.gov/before-you-ship/) site (around ATOs, etc.)
 * [Compliance pipelines for Concourse](https://github.com/18F/concourse-compliance-testing)


### PR DESCRIPTION
also replace trello link with zenhub link.
