### PR TITLE
Omit YAML editor from Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ We aim to:
 
 #### Tooling
 - [Compliance Masonry CLI](https://github.com/opencontrol/compliance-masonry): CLI tool for building docs.  
-- [OpenControl YAML Editor](https://github.com/opencontrol/OpenControl-YAML-editor).  
 - [doc-template](https://github.com/opencontrol/doc-template): A library that extends golang's template engine to docx.  
 
 #### OpenControl schemas

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ We aim to:
 #### Tooling
 - [Compliance Masonry CLI](https://github.com/opencontrol/compliance-masonry): CLI tool for building docs.  
 - [doc-template](https://github.com/opencontrol/doc-template): A library that extends golang's template engine to docx.  
+- [OpenControl YAML Editor](https://github.com/opencontrol/OpenControl-YAML-editor): _Experimental/Prototype_ web-based YAML document editor. Not yet a useful tool, included here for reference.
 
 #### OpenControl schemas
 - [OpenControl Schemas](https://github.com/opencontrol/schemas): Schemas for data organized in the OpenControl format.  


### PR DESCRIPTION
The YAML editor is too raw to be useful to anyone perusing compliance toolkit,
and is a distraction from getting started.

I think it's cool that someone is trying out new tooling, but I'd like to save others the time until its further along.

Meanwhile, a `generator` command to compliance-masonry would probably be more useful (and tips to use editors that understand YAML)
